### PR TITLE
Flags identified as matched incorrectly 

### DIFF
--- a/auditeval/test_test.go
+++ b/auditeval/test_test.go
@@ -49,8 +49,39 @@ func TestTestExecute(t *testing.T) {
 
 	for _, c := range cases {
 		res := ts.Execute(c.str)
-		if res != c.want {
+		if res.TestResult != c.want {
 			t.Errorf("expected:%v, got:%v\n", c.want, res)
+		}
+	}
+}
+
+func Test_getFlagValue(t *testing.T) {
+
+	type TestRegex struct {
+		Input    string
+		Flag     string
+		Expected string
+	}
+
+	tests := []TestRegex{
+		{Input: "XXX: User=root XXX", Flag: "User", Expected: "root"},
+		{Input: "XXX: User=", Flag: "User", Expected: ""},
+		{Input: "XXX: User= AAA XXX", Flag: "User", Expected: ""},
+		{Input: "XXX: XXX User=some_user XXX", Flag: "User", Expected: "some_user"},
+		{Input: "--flag=AAA,BBB,CCC XXX", Flag: "--flag", Expected: "AAA,BBB,CCC"},
+		{Input: "--flag", Flag: "--flag", Expected: "--flag"},
+		{Input: "XXX --flag AAA XXX", Flag: "--flag", Expected: "AAA"},
+		{Input: "XXX --AAA BBB", Flag: "XXX", Expected: "XXX"},
+		{Input: "XXX", Flag: "XXX", Expected: "XXX"},
+		{Input: "CCC XXX AAA BBB", Flag: "XXX", Expected: "AAA"},
+		{Input: "YXXX", Flag: "XXX", Expected: ""},
+		{Input: "XXXY", Flag: "XXX", Expected: ""},
+	}
+
+	for i, test := range tests {
+		actual := getFlagValue(test.Input, test.Flag)
+		if test.Expected != actual {
+			t.Errorf("test %d fail: expected: %v actual: %v\ntest details: %+v\n", i, test.Expected, actual, test)
 		}
 	}
 }


### PR DESCRIPTION
During running of the CIS checks, there are checks which give incorrect results, that is FAIL when
expected to be PASS and vice-versa. The reason is that `execute()` function does string parsing
incorrectly which results in false positive/negative results. Specifically the `strings.Contains()` is used which can mistakenly find prefix of the matched flag and not the flag itself. Another reason is that there are cases when `execute()` just checks that flag is not present when it is expected to do
more careful checking. For example: check 2.5. The check returns FAIL when actually docker does not have aufs storage driver set.

Fixed by changing execute() flow using correct regex to fetch the flag value.