### PR TITLE
Revert "Make changes to support migrating kube-bench."

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -56,7 +56,8 @@ type Check struct {
 	Commands    []*exec.Cmd      `json:"omit"`
 	Tests       *auditeval.Tests `json:"omit"`
 	Set         bool             `json:"omit"`
-	Remediation string           `json:"remediation"`
+	Remediation string           `json:"-"`
+	TestInfo    []string         `json:"test_info"`
 	State       `json:"status"`
 	ActualValue string `json:"actual_value"`
 }
@@ -66,6 +67,9 @@ type Group struct {
 	ID          string   `yaml:"id" json:"section"`
 	Description string   `json:"desc"`
 	Checks      []*Check `json:"results"`
+	Pass        int      `json:"pass"`
+	Fail        int      `json:"fail"`
+	Warn        int      `json:"warn"`
 }
 
 // Run executes the audit commands specified in a check and outputs

--- a/check/controls.go
+++ b/check/controls.go
@@ -24,7 +24,7 @@ import (
 // Controls holds all controls to check for master nodes.
 type Controls struct {
 	ID          string   `yaml:"id" json:"id"`
-	Description string   `json:"description"`
+	Description string   `json:"text"`
 	Groups      []*Group `json:"tests"`
 	Summary
 }
@@ -70,7 +70,9 @@ func (controls *Controls) RunGroup(gids ...string) Summary {
 			if gid == group.ID {
 				for _, check := range group.Checks {
 					check.Run()
+					check.TestInfo = append(check.TestInfo, check.Remediation)
 					summarize(controls, check)
+					summarizeGroup(group, check)
 				}
 
 				g = append(g, group)
@@ -99,6 +101,7 @@ func (controls *Controls) RunChecks(ids ...string) Summary {
 			for _, id := range ids {
 				if id == check.ID {
 					check.Run()
+					check.TestInfo = append(check.TestInfo, check.Remediation)
 					summarize(controls, check)
 
 					// Check if we have already added this checks group.
@@ -163,5 +166,16 @@ func summarize(controls *Controls, check *Check) {
 		controls.Summary.Fail++
 	case WARN:
 		controls.Summary.Warn++
+	}
+}
+
+func summarizeGroup(group *Group, check *Check) {
+	switch check.State {
+	case PASS:
+		group.Pass++
+	case FAIL:
+		group.Fail++
+	case WARN:
+		group.Warn++
 	}
 }

--- a/check/controls_test.go
+++ b/check/controls_test.go
@@ -59,3 +59,33 @@ func TestRunChecks(t *testing.T) {
 
 	c.RunChecks("1.1.2")
 }
+
+func TestSummarizeGroup(t *testing.T) {
+		type TestCase struct {
+			state State
+			group Group
+			check Check
+			Expected int
+		}
+		var actual int
+
+		testCases := []TestCase{
+			{group:Group{},  check:Check{State: "PASS"}, Expected: 1},
+			{group:Group{},  check:Check{State: "FAIL"}, Expected: 1},
+			{group:Group{},  check:Check{State: "WARN"}, Expected: 1},
+		}
+		for i, test := range testCases {
+			summarizeGroup(&test.group, &test.check)
+			switch test.check.State {
+				case "PASS":
+					actual = test.group.Pass
+				case "FAIL":
+					actual = test.group.Fail
+				case "WARN":
+					actual = test.group.Warn
+			}
+			if actual != test.Expected {
+				t.Errorf("test %d fail: expected: %v actual: %v\ntest details: %+v\n", i, test.Expected, actual, test)
+			}
+		}
+}


### PR DESCRIPTION
This reverts commit 6ec5a8bd251dba3d119d5f356878b3e423a250ef.
since the group check results summarization is expected.
Added test which verifies presence of PASS, FAIL, WARN fields
of the group summarization.