### PR TITLE
Print output without remediations

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -86,7 +86,7 @@ func colorPrint(state check.State, s string) {
 }
 
 // prettyPrint outputs the results to stdout in human-readable format
-func PrettyPrint(r *check.Controls, summary check.Summary) {
+func PrettyPrint(r *check.Controls, summary check.Summary, noRemediations bool) {
 	colorPrint(check.INFO, fmt.Sprintf("%s %s\n", r.ID, r.Description))
 	for _, g := range r.Groups {
 		colorPrint(check.INFO, fmt.Sprintf("%s %s\n", g.ID, g.Description))
@@ -98,7 +98,7 @@ func PrettyPrint(r *check.Controls, summary check.Summary) {
 	fmt.Println()
 
 	// Print remediations.
-	if summary.Fail > 0 || summary.Warn > 0 {
+	if  !noRemediations && (summary.Fail > 0 || summary.Warn > 0) {
 		colors[check.WARN].Printf("== Remediations ==\n")
 		for _, g := range r.Groups {
 			for _, c := range g.Checks {


### PR DESCRIPTION
When flag --noremediations is set in the main app (Docker/Kube bench), the program will print the output without the remediation.
========
NOTICE! If this pull request will be merged than the corresponding pull request in the docker-bench must be merged also, or else the docker-bench won't compile!
