### PR TITLE
Added support for include-test-output attribute.

### DIFF
--- a/auditeval/test.go
+++ b/auditeval/test.go
@@ -154,8 +154,7 @@ func (ts *Tests) Execute(s string) *testOutput {
 		}
 	}
 	finalOutput.TestResult = result
-	finalOutput.ActualResult = res[0].ActualResult
-
+	finalOutput.ActualResult = s
 	return finalOutput
 }
 

--- a/check/check.go
+++ b/check/check.go
@@ -176,7 +176,6 @@ func (c *Check) Run() {
 		glog.V(1).Info("Test output contains a nil value")
 		return
 	}
-
 }
 
 // textToCommand transforms an input text representation of commands to be

--- a/util/util.go
+++ b/util/util.go
@@ -86,19 +86,23 @@ func colorPrint(state check.State, s string) {
 }
 
 // prettyPrint outputs the results to stdout in human-readable format
-func PrettyPrint(r *check.Controls, summary check.Summary, noRemediations bool) {
+func PrettyPrint(r *check.Controls, summary check.Summary, noRemediations, includeTestOutput bool) {
 	colorPrint(check.INFO, fmt.Sprintf("%s %s\n", r.ID, r.Description))
 	for _, g := range r.Groups {
 		colorPrint(check.INFO, fmt.Sprintf("%s %s\n", g.ID, g.Description))
 		for _, c := range g.Checks {
 			colorPrint(c.State, fmt.Sprintf("%s %s\n", c.ID, c.Description))
+
+			if includeTestOutput && c.State == check.FAIL && len(c.ActualValue) > 0 {
+				printRawOutput(c.ActualValue)
+			}
 		}
 	}
 
 	fmt.Println()
 
 	// Print remediations.
-	if  !noRemediations && (summary.Fail > 0 || summary.Warn > 0) {
+	if !noRemediations && (summary.Fail > 0 || summary.Warn > 0) {
 		colors[check.WARN].Printf("== Remediations ==\n")
 		for _, g := range r.Groups {
 			for _, c := range g.Checks {
@@ -209,4 +213,10 @@ func multiWordReplace(s string, subname string, sub string) string {
 	}
 
 	return strings.Replace(s, subname, sub, -1)
+}
+
+func printRawOutput(output string) {
+	for _, row := range strings.Split(output, "\n") {
+		fmt.Println(fmt.Sprintf("\t %s", row))
+	}
 }


### PR DESCRIPTION
Saving audit command output as Actualresult for each test.
If includeTestOutput attribute is set, and the test has failed, print the the command's result.

Print result example:
[WARN] 5.27 Ensure docker commands always get the latest version of the image (Not Scored)
[FAIL] 5.28 Ensure PIDs cgroup limit is used (Scored)
	 9fc8b0228b841b0b3f10a0d2ba6e7b40ed1f7841c1a9ebe293e2d2222660c5a0:PidsLimit=0
	 d002c44d906e2bcf3df28eace9ac3aaa7cae3a078b6d1d993b44cefbf2834266:PidsLimit=0
	 e43d19bcc39e46cc5e1ef83e4ec518866e2f76aa334cebc0e45d9c81aeeabb5e:PidsLimit=0
	 bbad4a6febbb315a500b5b1aa6500e71745f7c563aa4f879aa28cb29bdbccb65:PidsLimit=0
	 0a5bb7f67322adfda0395bf2aa07c3b93211d25a8651cf129956340f611e230f:PidsLimit=0
	 d770aa96271cfd32e4f68266ef7e3fc8b3e5aa52b05c0239181bd2d942ba7028:PidsLimit=0
	 23f910566a0cf1bdc47ec37f6092d9bce48fe56edca3d73052772b84be9e8cf9:PidsLimit=0
[FAIL] 5.29 Ensure Docker's default bridge docker0 is not used (Not Scored)