### PR TITLE
New test type - skip

### DIFF
--- a/app.go
+++ b/app.go
@@ -30,7 +30,7 @@ func app(cmd *cobra.Command, args []string) {
 
 func outputResults(controls *check.Controls, summary check.Summary) error {
 	// if we successfully ran some tests and it's json format, ignore the warnings
-	if (summary.Fail > 0 || summary.Warn > 0 || summary.Pass > 0) && jsonFmt {
+	if (summary.Fail > 0 || summary.Warn > 0 || summary.Pass > 0 || summary.Info > 0) && jsonFmt {
 		out, err := controls.JSON()
 		if err != nil {
 			return err

--- a/check/check.go
+++ b/check/check.go
@@ -68,10 +68,10 @@ type Group struct {
 	ID          string   `yaml:"id" json:"section"`
 	Description string   `json:"desc"`
 	Checks      []*Check `json:"results"`
-	Pass        int      `json:"pass"`
-	Fail        int      `json:"fail"`
-	Warn        int      `json:"warn"`
-	Info        int      `json:"info"`
+	Pass        int      `json:"pass"` // Tests with no type that passed
+	Fail        int      `json:"fail"` // Tests with no type that failed
+	Warn        int      `json:"warn"` // Tests of type manual won't be run and will be marked as Warn
+	Info        int      `json:"info"` // Tests of type skip won't be run and will be marked as Info
 }
 
 // Run executes the audit commands specified in a check and outputs

--- a/check/check.go
+++ b/check/check.go
@@ -71,6 +71,7 @@ type Group struct {
 	Pass        int      `json:"pass"`
 	Fail        int      `json:"fail"`
 	Warn        int      `json:"warn"`
+	Info        int      `json:"info"`
 }
 
 // Run executes the audit commands specified in a check and outputs
@@ -79,6 +80,11 @@ func (c *Check) Run() {
 	// If check type is manual, force result to WARN.
 	if c.Type == "manual" {
 		c.State = WARN
+		return
+	}
+
+	if c.Type == "skip" {
+		c.State = INFO
 		return
 	}
 

--- a/check/controls.go
+++ b/check/controls.go
@@ -34,6 +34,7 @@ type Summary struct {
 	Pass int `json:"total_pass"`
 	Fail int `json:"total_fail"`
 	Warn int `json:"total_warn"`
+	Info int `json:"total_info"`
 }
 
 // NewControls instantiates a new master Controls object.
@@ -58,7 +59,7 @@ func NewControls(in []byte) (*Controls, error) {
 // RunGroup runs all checks in a group.
 func (controls *Controls) RunGroup(gids ...string) Summary {
 	g := []*Group{}
-	controls.Summary.Pass, controls.Summary.Fail, controls.Summary.Warn = 0, 0, 0
+	controls.Summary.Pass, controls.Summary.Fail, controls.Summary.Warn, controls.Summary.Info = 0, 0, 0, 0
 
 	// If no groupid is passed run all group checks.
 	if len(gids) == 0 {
@@ -89,7 +90,7 @@ func (controls *Controls) RunGroup(gids ...string) Summary {
 func (controls *Controls) RunChecks(ids ...string) Summary {
 	g := []*Group{}
 	m := make(map[string]*Group)
-	controls.Summary.Pass, controls.Summary.Fail, controls.Summary.Warn = 0, 0, 0
+	controls.Summary.Pass, controls.Summary.Fail, controls.Summary.Warn, controls.Summary.Info = 0, 0, 0, 0
 
 	// If no groupid is passed run all group checks.
 	if len(ids) == 0 {
@@ -166,6 +167,8 @@ func summarize(controls *Controls, check *Check) {
 		controls.Summary.Fail++
 	case WARN:
 		controls.Summary.Warn++
+	case INFO:
+		controls.Summary.Info++
 	}
 }
 
@@ -177,5 +180,7 @@ func summarizeGroup(group *Group, check *Check) {
 		group.Fail++
 	case WARN:
 		group.Warn++
+	case INFO:
+		group.Info++
 	}
 }

--- a/util/util.go
+++ b/util/util.go
@@ -102,7 +102,7 @@ func PrettyPrint(r *check.Controls, summary check.Summary, noRemediations, inclu
 	fmt.Println()
 
 	// Print remediations.
-	if !noRemediations && (summary.Fail > 0 || summary.Warn > 0) {
+	if !noRemediations && (summary.Fail > 0 || summary.Warn > 0 || summary.Info > 0) {
 		colors[check.WARN].Printf("== Remediations ==\n")
 		for _, g := range r.Groups {
 			for _, c := range g.Checks {
@@ -120,13 +120,15 @@ func PrettyPrint(r *check.Controls, summary check.Summary, noRemediations, inclu
 		res = check.FAIL
 	} else if summary.Warn > 0 {
 		res = check.WARN
+	} else if summary.Info > 0 {
+		res = check.INFO
 	} else {
 		res = check.PASS
 	}
 
 	colors[res].Printf("== Summary ==\n")
-	fmt.Printf("%d checks PASS\n%d checks FAIL\n%d checks WARN\n",
-		summary.Pass, summary.Fail, summary.Warn,
+	fmt.Printf("%d checks PASS\n%d checks FAIL\n%d checks WARN\n%d checks INFO\n",
+		summary.Pass, summary.Fail, summary.Warn, summary.Info,
 	)
 }
 


### PR DESCRIPTION
When a test is of type skip, it will not run and will be marked as "info".
There is a new category in the tests summary called "Info" that holds the amount of all the tests resulted with status "Info".

In this example I marked the first 4 tests as type skip:

![image](https://user-images.githubusercontent.com/44805943/50958485-7971e480-14c9-11e9-9902-47f54857482d.png)
