### PR TITLE
Bugfix: Tests with multiple values evaluate the first value instead of all

### DIFF
--- a/auditeval/test_test.go
+++ b/auditeval/test_test.go
@@ -32,6 +32,28 @@ test_items:
   set: true
 `
 
+const testMultiple = `
+---
+tests:
+bin_op: and
+test_items:
+- flag: "User"
+  compare:
+    op: nothave
+    value: "root"
+  set: true
+- flag: "User"
+  compare:
+    op: noteq
+    value: ""
+  set: true
+- flag: "User"
+  compare:
+    op: noteq
+    value: "1"
+  set: true
+`
+
 // TODO: Write more test cases.
 func TestTestExecute(t *testing.T) {
 	ts := new(Tests)
@@ -48,7 +70,7 @@ func TestTestExecute(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		res := ts.Execute(c.str)
+		res := ts.Execute(c.str, false)
 		if res.TestResult != c.want {
 			t.Errorf("expected:%v, got:%v\n", c.want, res)
 		}
@@ -82,6 +104,65 @@ func Test_getFlagValue(t *testing.T) {
 		actual := getFlagValue(test.Input, test.Flag)
 		if test.Expected != actual {
 			t.Errorf("test %d fail: expected: %v actual: %v\ntest details: %+v\n", i, test.Expected, actual, test)
+		}
+	}
+}
+
+// Test for multi-output functionality
+// Some of the tests checks for a list of results in the single output
+// These tests should set the flag "use_multiple_values" to true
+// Testing for multiple values in output with the flag set/not-set and for different combinations of results
+// Test simulation is number 4.1 in docker-bench 17.06 yaml file
+func Test_ExecuteMultipleOutput(t *testing.T) {
+	//    audit: "docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}: User={{ .Config.User }}'"
+	//    use_multiple_values: true/false
+
+	ts := new(Tests)
+	if err := yaml.Unmarshal([]byte(testMultiple), ts); err != nil {
+		t.Fatalf("error unmarshaling tests yaml")
+	}
+
+	cases := []struct {
+		auditCommandOutput  string
+		expectedResult bool
+		testWithMultiple bool
+	}{
+		// If the use_multiple_values is not set, test should pass on first container (The bug)
+		{`b24f2b421ec7742ad6417263c34fcc1086e83ca6b9d4f759ff8671a0f9fc68ac: User=Pass
+			9bf99c968c5a96c9d7913609867deffce0d59b90429a7e6a584485eec69067d1: User=
+			af1072975e9e129489a75b9aa3cac7cc613bda4901e0ca2369366a7297d3e3ca: User=`,
+		true, false,
+		},
+		// If the use_multiple_values is not set, test should fail on first container
+		{`b24f2b421ec7742ad6417263c34fcc1086e83ca6b9d4f759ff8671a0f9fc68ac: User=
+			9bf99c968c5a96c9d7913609867deffce0d59b90429a7e6a584485eec69067d1: User=ShouldFail
+			af1072975e9e129489a75b9aa3cac7cc613bda4901e0ca2369366a7297d3e3ca: User=NoUse`,
+			false, false,
+		},
+		// If the use_multiple_values is set, test should fail on second container (first to fail the test)
+		{`b24f2b421ec7742ad6417263c34fcc1086e83ca6b9d4f759ff8671a0f9fc68ac: User=Pass
+			9bf99c968c5a96c9d7913609867deffce0d59b90429a7e6a584485eec69067d1: User=
+			af1072975e9e129489a75b9aa3cac7cc613bda4901e0ca2369366a7297d3e3ca: User=`,
+			false, true,
+		},
+		// If the use_multiple_values is set, test should fail on first container (first to fail the test)
+		{`b24f2b421ec7742ad6417263c34fcc1086e83ca6b9d4f759ff8671a0f9fc68ac: User=root
+			9bf99c968c5a96c9d7913609867deffce0d59b90429a7e6a584485eec69067d1: User=a
+			af1072975e9e129489a75b9aa3cac7cc613bda4901e0ca2369366a7297d3e3ca: User=b`,
+			false, true,
+		},
+		// If the use_multiple_values is set, test should pass
+		{`b24f2b421ec7742ad6417263c34fcc1086e83ca6b9d4f759ff8671a0f9fc68ac: User=Pass
+			9bf99c968c5a96c9d7913609867deffce0d59b90429a7e6a584485eec69067d1: User=Pass1
+			af1072975e9e129489a75b9aa3cac7cc613bda4901e0ca2369366a7297d3e3ca: User=Pass`,
+			true, true,
+		},
+	}
+
+	for _, c := range cases {
+		res := ts.Execute(c.auditCommandOutput, c.testWithMultiple)
+		if res.TestResult != c.expectedResult {
+			t.Errorf("expected:%v, got:%v\n", c.expectedResult, res.TestResult)
 		}
 	}
 }

--- a/check/check.go
+++ b/check/check.go
@@ -77,6 +77,7 @@ type Check struct {
 	ActualValue    string `json:"actual_value"`
 	ExpectedResult string `json:"expected_result"`
 	Scored         bool   `json:"scored"`
+	IsMultiple     bool   `yaml:"use_multiple_values"`
 }
 
 // Group is a collection of similar checks.
@@ -125,7 +126,7 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 		return
 	}
 
-	finalOutput := subCheck.Tests.Execute(out.String())
+	finalOutput := subCheck.Tests.Execute(out.String(), c.IsMultiple)
 
 	if finalOutput != nil {
 		c.ActualValue = finalOutput.ActualResult


### PR DESCRIPTION


When adding to a test the attribute "use_multiple_values: true" it will evaluate each result in the test's output

Fix #4