### PR TITLE
Now accepting " = " (with spaces) 

### DIFF
--- a/auditeval/test.go
+++ b/auditeval/test.go
@@ -154,8 +154,8 @@ func getFlagValue(s, flag string) string {
 
 	var flagVal string
 	pttns := []string{
-		flag + `="(.*)"`,
-		flag + `=([^ \n]*)`,
+		flag + `\s*=\s*"(.*)"`,
+		flag + `\s*=([^ \n]*)`,
 		flag + ` +([^- ]+)`,
 		`(?:^| +)` + `(` + flag + `)` + `(?: |$)`,
 	}


### PR DESCRIPTION
Added spaces regex matching on the flag parsing. 
Works with the tests expected results, to pass the CI
related #35 