### PR TITLE
Now accepting " = " (with spaces) 

### DIFF
--- a/auditeval/test.go
+++ b/auditeval/test.go
@@ -154,8 +154,8 @@ func getFlagValue(s, flag string) string {
 
 	var flagVal string
 	pttns := []string{
-		flag + `="(.*)"`,
-		flag + `=([^ \n]*)`,
+		flag + `\s*=\s*"(.*)"`,
+		flag + `\s*=([^ \n]*)`,
 		flag + ` +([^- ]+)`,
 		`(?:^| +)` + `(` + flag + `)` + `(?: |$)`,
 	}


### PR DESCRIPTION
related #35 
fixed to work with tests, although regex now only not matching cases with space after '=' and without double quates, so not matching:
`User= AAA`
But:
`User= "AAA"`
Matches.
If I try to match the first one:

> b24f2b421ec7742ad6417263c34fcc1086e83ca6b9d4f759ff8671a0f9fc68ac: User=Pass
>                                 9bf99c968c5a96c9d7913609867deffce0d59b90429a7e6a584485eec69067d1: User=Pass1
>                                 af1072975e9e129489a75b9aa3cac7cc613bda4901e0ca2369366a7297d3e3ca: User=Pass fail:

This TestWithMultiple fails.
