### PR TITLE
This PR itroduce implementation for Custom Audit command

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -201,7 +201,6 @@ func textToCommand(s string) (cmds []*exec.Cmd) {
 	if s == "" {
 		return cmds
 	}
-	cmds = []*exec.Cmd{}
 
 	cp := strings.Split(s, "|")
 

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -26,13 +26,13 @@ func TestCheck_Run(t *testing.T) {
 
 	ts := new(auditeval.Tests)
 	if err := yaml.Unmarshal([]byte(def1), ts); err != nil {
-		t.Fatalf("error unmarshaling tests yaml")
+		t.Fatalf("error unmarshaling tests yaml %v", err)
 	}
 
-	checkTypeManual := Check{Type: "manual", Commands: textToCommand("ps -ef"), Tests: ts, Scored: true}
-	checkTypeSkip := Check{Type: "skip", Commands: textToCommand("ps -ef"), Tests: ts, Scored: true}
-	checkNotScored := Check{Type: "", Commands: textToCommand("ps -ef"), Tests: ts, Scored: false}
-	checkNoTests := Check{Type: "", Scored: true}
+	checkTypeManual := Check{Type: "manual", Tests: ts, Scored: true, auditer: Audit("ps -ef")}
+	checkTypeSkip := Check{Type: "skip", Tests: ts, Scored: true, auditer: Audit("ps -ef")}
+	checkNotScored := Check{Type: "", Tests: ts, Scored: false, auditer: Audit("ps -ef")}
+	checkNoTests := Check{Type: "", Scored: true, auditer: Audit("")}
 
 	testCases := []TestCase{
 		{check: checkTypeManual, Expected: WARN},
@@ -53,19 +53,20 @@ func TestCheck_Run(t *testing.T) {
 
 func TestGetFirstValidSubCheck(t *testing.T) {
 	type TestCase struct {
-		SubChecks []SubCheck
+		SubChecks []*SubCheck
 		Chosen    *BaseCheck
 		Expected  *BaseCheck
 	}
 
 	testCases := []TestCase{
 		{
-			SubChecks: []SubCheck{
+			SubChecks: []*SubCheck{
 				{
 					BaseCheck{
 						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"ubuntu"}},
 						Remediation: "Fake test, check that current user has home directory",
+						auditer:     Audit("ls /home | grep $USER"),
 					},
 				},
 				{
@@ -73,6 +74,7 @@ func TestGetFirstValidSubCheck(t *testing.T) {
 						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"Fail", "ubuntu", "grub"}},
 						Remediation: "Fake test, check that current user has home directory",
+						auditer:     Audit("ls /home | grep $USER"),
 					},
 				},
 			},
@@ -80,15 +82,17 @@ func TestGetFirstValidSubCheck(t *testing.T) {
 				Audit:       "ls /home | grep $USER",
 				Constraints: map[string][]string{"platform": []string{"ubuntu"}},
 				Remediation: "Fake test, check that current user has home directory",
+				auditer:     Audit("ls /home | grep $USER"),
 			},
 		},
 		{
-			SubChecks: []SubCheck{
+			SubChecks: []*SubCheck{
 				{
 					BaseCheck{
 						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"ubuntu", "p"}},
 						Remediation: "Fake test, check that current user has home directory",
+						auditer:     Audit("ls /home | grep $USER"),
 					},
 				},
 				{
@@ -96,6 +100,7 @@ func TestGetFirstValidSubCheck(t *testing.T) {
 						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"Fail", "ubuntu", "grub"}},
 						Remediation: "Fake test, check that current user has home directory",
+						auditer:     Audit("ls /home | grep $USER"),
 					},
 				},
 			},

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -63,7 +63,6 @@ func TestGetFirstValidSubCheck(t *testing.T) {
 			SubChecks: []*SubCheck{
 				{
 					BaseCheck{
-						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"ubuntu"}},
 						Remediation: "Fake test, check that current user has home directory",
 						auditer:     Audit("ls /home | grep $USER"),
@@ -79,7 +78,6 @@ func TestGetFirstValidSubCheck(t *testing.T) {
 				},
 			},
 			Expected: &BaseCheck{
-				Audit:       "ls /home | grep $USER",
 				Constraints: map[string][]string{"platform": []string{"ubuntu"}},
 				Remediation: "Fake test, check that current user has home directory",
 				auditer:     Audit("ls /home | grep $USER"),
@@ -89,7 +87,6 @@ func TestGetFirstValidSubCheck(t *testing.T) {
 			SubChecks: []*SubCheck{
 				{
 					BaseCheck{
-						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"ubuntu", "p"}},
 						Remediation: "Fake test, check that current user has home directory",
 						auditer:     Audit("ls /home | grep $USER"),
@@ -97,7 +94,6 @@ func TestGetFirstValidSubCheck(t *testing.T) {
 				},
 				{
 					BaseCheck{
-						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"Fail", "ubuntu", "grub"}},
 						Remediation: "Fake test, check that current user has home directory",
 						auditer:     Audit("ls /home | grep $USER"),

--- a/check/controls.go
+++ b/check/controls.go
@@ -17,8 +17,9 @@ package check
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
 	"strings"
+
+	"github.com/golang/glog"
 
 	"gopkg.in/yaml.v2"
 )
@@ -77,14 +78,17 @@ func NewControls(in []byte, definitions []string, customConfigs ...interface{}) 
 func (controls *Controls) convertAuditToRegisteredType(auditType AuditType, audit interface{}) (auditer Auditer, err error) {
 
 	var auditBytes []byte
+	var callback func() interface{}
+	var ok bool
+
 	if auditType == "" || auditType == TypeAudit {
-		if s, ok := audit.(string);  ok || audit == nil {
+		if s, ok := audit.(string); ok || audit == nil {
 			return Audit(s), nil
 		}
 		return nil, fmt.Errorf("failed to convert audit, mismatching type")
 	}
-	
-	if callback, ok := controls.auditTypeRegistry[auditType]; !ok {
+
+	if callback, ok = controls.auditTypeRegistry[auditType]; !ok {
 		return nil, fmt.Errorf("audit type %v is not registered", auditType)
 	}
 
@@ -92,7 +96,7 @@ func (controls *Controls) convertAuditToRegisteredType(auditType AuditType, audi
 	if auditBytes, err = yaml.Marshal(audit); err == nil {
 		return nil, fmt.Errorf("unable to marshal Audit %v", err)
 	}
-	
+
 	if err := yaml.Unmarshal(auditBytes, o); err != nil {
 		return nil, fmt.Errorf("unable to Unmarshal Audit %v", err)
 	}

--- a/check/controls.go
+++ b/check/controls.go
@@ -85,12 +85,12 @@ func (controls *Controls) convertAuditToRegisteredType(auditType AuditType, audi
 	}
 	
 	if callback, ok := controls.auditTypeRegistry[auditType]; !ok {
-		return nil, fmt.Errorf("unable to marshal Audit %v", err)
+		return nil, fmt.Errorf("audit type %v is not registered", auditType)
 	}
 
 	o := callback()
 	if auditBytes, err = yaml.Marshal(audit); err == nil {
-		return nil, fmt.Errorf("audit type %v is not registered", auditType)
+		return nil, fmt.Errorf("unable to marshal Audit %v", err)
 	}
 	
 	if err := yaml.Unmarshal(auditBytes, o); err != nil {


### PR DESCRIPTION
We turn the audit attribute in Checks struct to custom object
As part of this PR  development I introduced new entity called AuditType
that contains definition  how to desterilize the audit attribute

In general, the Controls struct keeps factory map AuditType versus its
implementation
New implementations might be registered outside of common-bench using
new method in Controls struct

RegisterAuditType(auditType AuditType, typeCallback func()interface{})

the callback function implementation shall return new instance of custom
struct that implements interface 'Auditer'.

'Auditer' interface declares new methods
Execute(customConfigs...interface{})
this method envokes the custom audit implementation and customConfigs
contains some external configuratin

When audit type not provided or it is a regular ‘audit’, it is behaves as shell
command to support old yamls