### PR TITLE
This PR itroduce implementation for Custom Audit command

### DIFF
--- a/check/bench.go
+++ b/check/bench.go
@@ -50,7 +50,6 @@ func (b *bench) RegisterAuditType(auditType AuditType, typeCallback func() inter
 
 func (b *bench) NewControls(in []byte, definitions []string, customConfigs ...interface{}) (*Controls, error) {
 	c := new(Controls)
-	//c.auditTypeRegistry = defaultBench.auditTypeRegistry
 	err := yaml.Unmarshal(in, c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal YAML: %s", err)

--- a/check/bench.go
+++ b/check/bench.go
@@ -1,0 +1,128 @@
+// Copyright © 2019 Aqua Security Software Ltd. <info@aquasec.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package check
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	"gopkg.in/yaml.v2"
+)
+
+type Bench interface {
+	RegisterAuditType(auditType AuditType, typeCallback func() interface{}) error
+	NewControls(in []byte, definitions []string, customConfigs ...interface{}) (*Controls, error)
+}
+
+type bench struct {
+	auditTypeRegistry map[AuditType]func() interface{}
+}
+
+func NewBench() Bench {
+	return &bench{auditTypeRegistry:make(map[AuditType]func() interface{})}
+}
+
+func (b *bench) RegisterAuditType(auditType AuditType, typeCallback func() interface{}) error {
+
+	if _, ok := b.auditTypeRegistry[auditType]; ok {
+		return fmt.Errorf("audit type %v already registered", auditType)
+	}
+	a := typeCallback()
+	if _, ok := a.(Auditer); ok {
+		b.auditTypeRegistry[auditType] = typeCallback
+		return nil
+	}
+	return fmt.Errorf("audit type %v must implement Auditer interface", auditType)
+
+}
+
+func (b *bench) NewControls(in []byte, definitions []string, customConfigs ...interface{}) (*Controls, error) {
+	c := new(Controls)
+	//c.auditTypeRegistry = defaultBench.auditTypeRegistry
+	err := yaml.Unmarshal(in, c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal YAML: %s", err)
+	}
+	c.customConfigs = customConfigs
+	if len(definitions) > 0 {
+		c.DefinedConstraints = map[string][]string{}
+		for _, val := range definitions {
+			a := strings.Split(val, "=")
+
+			// If its type 'category=value' for example 'platform=ubuntu'
+			if len(a) == 2 && a[0] != "" && a[1] != "" {
+				c.DefinedConstraints[a[0]] = append(c.DefinedConstraints[a[0]], a[1])
+			} else {
+				glog.V(1).Info("failed to parse defined constraint, ", val)
+			}
+		}
+	}
+	if err := b.extractAllAudits(c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (b *bench) convertAuditToRegisteredType(auditType AuditType, audit interface{}) (auditer Auditer, err error) {
+
+	var auditBytes []byte
+	var callback func() interface{}
+	var ok bool
+
+	if auditType == "" || auditType == TypeAudit {
+		if s, ok := audit.(string); ok || audit == nil {
+			return Audit(s), nil
+		}
+		return nil, fmt.Errorf("failed to convert audit, mismatching type")
+	}
+
+	if callback, ok = b.auditTypeRegistry[auditType]; !ok {
+		return nil, fmt.Errorf("audit type %v is not registered", auditType)
+	}
+
+	o := callback()
+	if auditBytes, err = yaml.Marshal(audit); err != nil {
+		return nil, fmt.Errorf("unable to marshal Audit %v", err)
+	}
+
+	if err := yaml.Unmarshal(auditBytes, o); err != nil {
+		return nil, fmt.Errorf("unable to Unmarshal Audit %v", err)
+	}
+	return o.(Auditer), nil
+}
+
+func (b *bench) extractAllAudits(controls *Controls) (err error) {
+	var audit Auditer
+	for _, group := range controls.Groups {
+		for _, check := range group.Checks {
+			if check.SubChecks == nil {
+				if audit, err = b.convertAuditToRegisteredType(check.AuditType, check.Audit); err != nil {
+					return err
+				}
+				check.auditer = audit
+				check.customConfigs = controls.customConfigs
+			} else {
+				for _, subCheck := range check.SubChecks {
+					if audit, err = b.convertAuditToRegisteredType(subCheck.AuditType, subCheck.Audit); err != nil {
+						return err
+					}
+					subCheck.auditer = audit
+					subCheck.customConfigs = controls.customConfigs
+				}
+			}
+		}
+	}
+	return err
+}

--- a/check/bench_test.go
+++ b/check/bench_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-const check = `---
+const controlYaml = `---
 controls:
 id: 1
 text: "Master Node Security Configuration"
@@ -59,7 +59,7 @@ func TestNewControlsWrongType(t *testing.T) {
 		wantErr bool
 	}{
 		{"create controls test",
-			args{[]byte(check), []string{}},
+			args{[]byte(controlYaml), []string{}},
 			nil,
 			true},
 	}

--- a/check/bench_test.go
+++ b/check/bench_test.go
@@ -40,7 +40,7 @@ func Test_bench_RegisterAuditType_Already_Registered(t *testing.T) {
 		return
 	}
 	if err := bench.RegisterAuditType(TypeAudit, func() interface{} { return Audit("test") }); err == nil {
-		t.Errorf("RegisterAuditType failed on duplicate types")
+		t.Errorf("RegisterAuditType should have failed on duplicate types")
 		return
 	}
 

--- a/check/bench_test.go
+++ b/check/bench_test.go
@@ -31,7 +31,7 @@ groups:
       scored: true
 `
 
-func Test_bench_RegisterAuditType_Already_Registered(t *testing.T) {
+func TestRegisterAuditType(t *testing.T) {
 
 	bench := NewBench()
 
@@ -46,7 +46,7 @@ func Test_bench_RegisterAuditType_Already_Registered(t *testing.T) {
 
 }
 
-func Test_bench_NewControls_wrong_type(t *testing.T) {
+func TestNewControlsWrongType(t *testing.T) {
 
 	type args struct {
 		in          []byte
@@ -78,7 +78,7 @@ func Test_bench_NewControls_wrong_type(t *testing.T) {
 	}
 }
 
-func TestExtractAllAudits_for_default_bench(t *testing.T) {
+func TestExtractAllAuditsForDefaultBench(t *testing.T) {
 
 	c, err := NewControls([]byte(def), nil)
 	if err != nil {

--- a/check/bench_test.go
+++ b/check/bench_test.go
@@ -1,0 +1,143 @@
+package check
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+
+const check = `---
+controls:
+id: 1
+text: "Master Node Security Configuration"
+type: "master"
+groups:
+- id: 1.1
+  text: "API Server"
+  checks:
+    - id: 1.1.1
+      text: "Ensure that the --allow-privileged argument is set to false (Scored)"
+      audittype: "wrong_type"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "allow-privileged"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set 
+              the KUBE_ALLOW_PRIV parameter to \"--allow-privileged=false\""
+      scored: true
+`
+
+
+func Test_bench_RegisterAuditType_Already_Registered(t *testing.T) {
+
+	bench := NewBench()
+
+	if err := bench.RegisterAuditType(TypeAudit, func() interface{} {
+		return Audit("test")
+	})	; err != nil{
+
+		t.Errorf("Failed to register new Audit type")
+		return
+	}
+	if err := bench.RegisterAuditType(TypeAudit, func() interface{} {
+		return Audit("test")
+	})	; err == nil{
+
+		t.Errorf("RegisterAuditType failed on duplicate types")
+		return
+	}
+
+}
+
+func Test_bench_NewControls_wrong_type(t *testing.T) {
+
+	type args struct {
+		in            []byte
+		definitions   []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Controls
+		wantErr bool
+	}{
+		{"create controls test",
+			args{[]byte(check), []string{}},
+		nil,
+		true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &bench{}
+			got, err := b.NewControls(tt.args.in, tt.args.definitions)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("bench.NewControls() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("bench.NewControls() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+
+func TestExtractAllAudits_for_default_bench(t *testing.T) {
+
+	c, err := NewControls([]byte(def), nil)
+	if err != nil {
+		t.Fatalf("could not create control object: %s", err)
+	}
+
+	err = defaultBench.extractAllAudits(c)
+	if err != nil {
+		t.Fatalf("test failed: %v", err)
+	}
+
+	for _, g := range c.Groups {
+		for _, c := range g.Checks {
+
+			if c.Audit != nil && c.Audit != "" {
+				if c.auditer == nil {
+					t.Errorf("ID %s: Unexpected nil auditer", c.ID)
+					continue
+				}
+				audit, ok := c.auditer.(Audit)
+				if !ok {
+					t.Errorf("ID %s: Couldn't convert auditer %v to Audit", c.ID, c.auditer)
+				}
+				if c.Audit == nil && string(audit) == "" { // nothing to check when no audit attribute in check
+					continue
+				}
+				if string(audit) != c.Audit {
+					t.Errorf("ID %s: extracted audit %s, doesn't match audit string %s", c.ID, string(audit), c.Audit)
+				}
+			}
+
+			for _, s := range c.SubChecks {
+				if s.Audit != nil && s.Audit != "" {
+
+					if s.auditer == nil {
+						t.Errorf("ID %s: Unexpected nil auditer", c.ID)
+						continue
+					}
+					audit, ok := s.auditer.(Audit)
+					if !ok {
+						t.Errorf("ID %s: Couldn't convert auditer %v to Audit", c.ID, s.auditer)
+					}
+					if s.Audit == nil && string(audit) == "" { // nothing to check when no audit attribute in check
+						continue
+					}
+					if string(audit) != fmt.Sprintf("%v", s.Audit) {
+						t.Errorf("ID %s: extracted audit %s, expected %v", c.ID, string(audit), s.Audit)
+					}
+				}
+			}
+		}
+	}
+}

--- a/check/bench_test.go
+++ b/check/bench_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 )
 
-
 const check = `---
 controls:
 id: 1
@@ -32,22 +31,15 @@ groups:
       scored: true
 `
 
-
 func Test_bench_RegisterAuditType_Already_Registered(t *testing.T) {
 
 	bench := NewBench()
 
-	if err := bench.RegisterAuditType(TypeAudit, func() interface{} {
-		return Audit("test")
-	})	; err != nil{
-
+	if err := bench.RegisterAuditType(TypeAudit, func() interface{} { return Audit("test") }); err != nil {
 		t.Errorf("Failed to register new Audit type")
 		return
 	}
-	if err := bench.RegisterAuditType(TypeAudit, func() interface{} {
-		return Audit("test")
-	})	; err == nil{
-
+	if err := bench.RegisterAuditType(TypeAudit, func() interface{} { return Audit("test") }); err == nil {
 		t.Errorf("RegisterAuditType failed on duplicate types")
 		return
 	}
@@ -57,8 +49,8 @@ func Test_bench_RegisterAuditType_Already_Registered(t *testing.T) {
 func Test_bench_NewControls_wrong_type(t *testing.T) {
 
 	type args struct {
-		in            []byte
-		definitions   []string
+		in          []byte
+		definitions []string
 	}
 	tests := []struct {
 		name    string
@@ -68,8 +60,8 @@ func Test_bench_NewControls_wrong_type(t *testing.T) {
 	}{
 		{"create controls test",
 			args{[]byte(check), []string{}},
-		nil,
-		true},
+			nil,
+			true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -85,7 +77,6 @@ func Test_bench_NewControls_wrong_type(t *testing.T) {
 		})
 	}
 }
-
 
 func TestExtractAllAudits_for_default_bench(t *testing.T) {
 

--- a/check/bench_test.go
+++ b/check/bench_test.go
@@ -139,8 +139,6 @@ func TestExtractAllAuditsForDefaultBench(t *testing.T) {
 			}
 
 			for _, s := range c.SubChecks {
-				if s.Audit != nil && s.Audit != "" {
-
 					if s.auditer == nil {
 						t.Errorf("ID %s: Unexpected nil auditer", c.ID)
 						continue
@@ -155,7 +153,6 @@ func TestExtractAllAuditsForDefaultBench(t *testing.T) {
 					if string(audit) != fmt.Sprintf("%v", s.Audit) {
 						t.Errorf("ID %s: extracted audit %s, expected %v", c.ID, string(audit), s.Audit)
 					}
-				}
 			}
 		}
 	}

--- a/check/check.go
+++ b/check/check.go
@@ -26,6 +26,38 @@ import (
 
 // State is the state of a control check.
 type State string
+type AuditType string
+
+const TypeAudit = "audit"
+
+type Audit string
+
+func (audit Audit) Execute(customConfig ...interface{}) (result string, errMessage string, state State) {
+
+	commands := textToCommand(string(audit))
+
+	// Check if command exists or exit with WARN.
+	for _, cmd := range commands {
+		if !isShellCommand(cmd.Path) {
+			glog.V(1).Infof("%s: command not found", cmd.Path)
+			return result, errMessage, WARN
+		}
+	}
+
+	// Run commands.
+	n := len(commands)
+	if n == 0 {
+		// Likely a warning message.
+		return result, errMessage, WARN
+	}
+
+	res, err := exec.Command("sh", "-c", string(audit) ).Output()
+
+	if err != nil {
+		errMessage = err.Error()
+	}
+	return string(res), errMessage, ""
+}
 
 const (
 	// PASS check passed.
@@ -47,12 +79,15 @@ func handleError(err error, context string) (errmsg string) {
 
 // Old version - checks don't have sub checks, each check has only one sub check as part of the check itself
 type BaseCheck struct {
-	Audit       string              `json:"audit"`
-	Type        string              `json:"type"`
-	Commands    []*exec.Cmd         `json:"omit"`
-	Tests       *auditeval.Tests    `json:"omit"`
-	Remediation string              `json:"-"`
-	Constraints map[string][]string `yaml:"constraints"`
+	AuditType     AuditType           `json:"audit_type"`
+	Audit         interface{}         `json:"audit"`
+	Type          string              `json:"type"`
+	Commands      []*exec.Cmd         `json:"omit"`
+	Tests         *auditeval.Tests    `json:"omit"`
+	Remediation   string              `json:"-"`
+	Constraints   map[string][]string `yaml:"constraints"`
+	auditer       Auditer
+	customConfigs []interface{}
 }
 
 type SubCheck struct {
@@ -64,8 +99,9 @@ type Check struct {
 	ID             string           `yaml:"id" json:"test_number"`
 	Description    string           `json:"test_desc"`
 	Set            bool             `json:"omit"`
-	SubChecks      []SubCheck       `yaml:"sub_checks"`
-	Audit          string           `json:"audit"`
+	SubChecks      []*SubCheck       `yaml:"sub_checks"`
+	AuditType      AuditType        `json:"audit_type"`
+	Audit          interface{}      `json:"omit"`
 	Type           string           `json:"type"`
 	Commands       []*exec.Cmd      `json:"omit"`
 	Tests          *auditeval.Tests `json:"omit"`
@@ -76,6 +112,8 @@ type Check struct {
 	ExpectedResult string `json:"expected_result"`
 	Scored         bool   `json:"scored"`
 	IsMultiple     bool   `yaml:"use_multiple_values"`
+	auditer        Auditer
+	customConfigs  []interface{}
 }
 
 // Group is a collection of similar checks.
@@ -107,11 +145,14 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 	var subCheck *BaseCheck
 	if c.SubChecks == nil {
 		subCheck = &BaseCheck{
-			Commands:    c.Commands,
-			Tests:       c.Tests,
-			Type:        c.Type,
-			Audit:       c.Audit,
-			Remediation: c.Remediation,
+			Commands:      c.Commands,
+			Tests:         c.Tests,
+			Type:          c.Type,
+			Audit:         c.Audit,
+			Remediation:   c.Remediation,
+			AuditType:     c.AuditType,
+			auditer:       c.auditer,
+			customConfigs: c.customConfigs,
 		}
 	} else {
 		subCheck = getFirstValidSubCheck(c.SubChecks, definedConstraints)
@@ -156,8 +197,10 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 // textToCommand transforms an input text representation of commands to be
 // run into a slice of commands.
 // TODO: Make this more robust.
-func textToCommand(s string) []*exec.Cmd {
-	cmds := []*exec.Cmd{}
+func textToCommand(s string) (cmds []*exec.Cmd) {
+	if s == "" {
+		return cmds
+	}
 
 	cp := strings.Split(s, "|")
 
@@ -223,34 +266,13 @@ func runAuditCommands(c BaseCheck) (output, errMessage string, state State) {
 	if c.Type == "skip" {
 		return output, errMessage, INFO
 	}
-
-	// Check if command exists or exit with WARN.
-	for _, cmd := range c.Commands {
-		if !isShellCommand(cmd.Path) {
-			glog.V(1).Infof("%s: command not found", cmd.Path)
-			return output, errMessage, WARN
-		}
+	if c.auditer != nil {
+		return c.auditer.Execute(c.customConfigs...)
 	}
-
-	// Run commands.
-	n := len(c.Commands)
-	if n == 0 {
-		// Likely a warning message.
-		return output, errMessage, WARN
-	}
-
-	out, err := exec.Command("sh", "-c", c.Audit).Output()
-
-	if err != nil {
-		errMessage = err.Error()
-	}
-
-	output = string(out)
-
-	return output, errMessage, ""
+	return
 }
 
-func getFirstValidSubCheck(subChecks []SubCheck, definedConstraints map[string][]string) (subCheck *BaseCheck) {
+func getFirstValidSubCheck(subChecks []*SubCheck, definedConstraints map[string][]string) (subCheck *BaseCheck) {
 	for _, sc := range subChecks {
 		isSubCheckOk := true
 

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -26,13 +26,13 @@ func TestCheck_Run(t *testing.T) {
 
 	ts := new(auditeval.Tests)
 	if err := yaml.Unmarshal([]byte(def1), ts); err != nil {
-		t.Fatalf("error unmarshaling tests yaml")
+		t.Fatalf("error unmarshaling tests yaml %v", err)
 	}
 
-	checkTypeManual := Check{Type: "manual", Commands: textToCommand("ps -ef"), Tests: ts, Scored: true}
-	checkTypeSkip := Check{Type: "skip", Commands: textToCommand("ps -ef"), Tests: ts, Scored: true}
-	checkNotScored := Check{Type: "", Commands: textToCommand("ps -ef"), Tests: ts, Scored: false}
-	checkNoTests := Check{Type: "", Scored: true}
+	checkTypeManual := Check{Type: "manual", Tests: ts, Scored: true, auditer: Audit("ps -ef")}
+	checkTypeSkip := Check{Type: "skip", Tests: ts, Scored: true, auditer: Audit("ps -ef")}
+	checkNotScored := Check{Type: "", Tests: ts, Scored: false, auditer: Audit("ps -ef")}
+	checkNoTests := Check{Type: "", Scored: true, auditer: Audit("")}
 
 	testCases := []TestCase{
 		{check: checkTypeManual, Expected: WARN},
@@ -53,19 +53,19 @@ func TestCheck_Run(t *testing.T) {
 
 func TestGetFirstValidSubCheck(t *testing.T) {
 	type TestCase struct {
-		SubChecks []SubCheck
+		SubChecks []*SubCheck
 		Chosen    *BaseCheck
 		Expected  *BaseCheck
 	}
 
 	testCases := []TestCase{
 		{
-			SubChecks: []SubCheck{
+			SubChecks: []*SubCheck{
 				{
 					BaseCheck{
-						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"ubuntu"}},
 						Remediation: "Fake test, check that current user has home directory",
+						auditer:     Audit("ls /home | grep $USER"),
 					},
 				},
 				{
@@ -73,29 +73,30 @@ func TestGetFirstValidSubCheck(t *testing.T) {
 						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"Fail", "ubuntu", "grub"}},
 						Remediation: "Fake test, check that current user has home directory",
+						auditer:     Audit("ls /home | grep $USER"),
 					},
 				},
 			},
 			Expected: &BaseCheck{
-				Audit:       "ls /home | grep $USER",
 				Constraints: map[string][]string{"platform": []string{"ubuntu"}},
 				Remediation: "Fake test, check that current user has home directory",
+				auditer:     Audit("ls /home | grep $USER"),
 			},
 		},
 		{
-			SubChecks: []SubCheck{
+			SubChecks: []*SubCheck{
 				{
 					BaseCheck{
-						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"ubuntu", "p"}},
 						Remediation: "Fake test, check that current user has home directory",
+						auditer:     Audit("ls /home | grep $USER"),
 					},
 				},
 				{
 					BaseCheck{
-						Audit:       "ls /home | grep $USER",
 						Constraints: map[string][]string{"platform": []string{"Fail", "ubuntu", "grub"}},
 						Remediation: "Fake test, check that current user has home directory",
+						auditer:     Audit("ls /home | grep $USER"),
 					},
 				},
 			},

--- a/check/controls_test.go
+++ b/check/controls_test.go
@@ -44,7 +44,7 @@ groups:
       text: "Ensure that the --allow-privileged argument is set to false (Scored)"
       sub_checks:
       - check:
-        audit: "ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "this is a subcheck audit string"
         tests:
           test_items:
           - flag: "allow-privileged"
@@ -52,6 +52,18 @@ groups:
               op: eq
               value: false
             set: true			  
+      remediation: "Make it work"
+      scored: true
+    - id: 1.1.3
+      text: "More than one test with tests rather than subchecks"
+      audit: "some other audit string"
+      tests:
+        test_items:
+        - flag: "allow-privileged"
+          compare:
+            op: eq
+            value: false
+          set: true			  
       remediation: "Make it work"
       scored: true
 `


### PR DESCRIPTION
We turn the audit attribute in Checks struct to custom object
As part of this PR  development I introduced new entity called AuditType
that contains definition  how to desterilize the audit attribute

In general, the Controls struct keeps factory map AuditType versus its
implementation
New implementations might be registered outside of common-bench using
new method in Controls struct

RegisterAuditType(auditType AuditType, typeCallback func()interface{})

the callback function implementation shall return new instance of custom
struct that implements interface 'Auditer'.

'Auditer' interface declares new methods
Execute(customConfigs...interface{})
this method envokes the custom audit implementation and customConfigs
contains some external configuratin

When audit type not provided or it is a regular ‘audit’, it is behaves as shell
command to support old yamls

This PR introduce new wrapper Bench struct
this structs wraps creating controls.

 for backward compatability we I added defaultBench variable in
checks
 that used when old NewControls invoked.