### PR TITLE
issue #50: exposes OutputResults functionality

### DIFF
--- a/app.go
+++ b/app.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+
 	"github.com/aquasecurity/bench-common/check"
 	"github.com/aquasecurity/bench-common/util"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"io/ioutil"
-	"os"
 )
 
 func app(cmd *cobra.Command, args []string) {
@@ -26,25 +27,15 @@ func Main(filePath string, constraints []string) {
 	}
 
 	summary := runControls(controls, "")
-	err = outputResults(controls, summary)
+	outcfg := &util.OutputConfig{
+		OutputFile:        outputFile,
+		NoRemediations:    noRemediations,
+		IncludeTestOutput: includeTestOutput,
+	}
+	err = util.OutputResults(controls, summary, outcfg)
 	if err != nil {
 		util.ExitWithError(err)
 	}
-}
-
-func outputResults(controls *check.Controls, summary check.Summary) error {
-	// if we successfully ran some tests and it's json format, ignore the warnings
-	if (summary.Fail > 0 || summary.Warn > 0 || summary.Pass > 0 || summary.Info > 0) && jsonFmt {
-		out, err := controls.JSON()
-		if err != nil {
-			return err
-		}
-		util.PrintOutput(string(out), outputFile)
-	} else {
-		util.PrettyPrint(controls, summary, noRemediations, includeTestOutput)
-	}
-
-	return nil
 }
 
 func runControls(controls *check.Controls, checkList string) check.Summary {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -138,7 +138,11 @@ func TestOutputResultsJSON(t *testing.T) {
 		JSONFmt:    true,
 	}
 	controls := &check.Controls{}
-	summary := check.Summary{}
+	summary := check.Summary{
+		Pass: 10,
+		Fail: 0,
+		Warn: 2,
+	}
 	err := OutputResults(controls, summary, outcfg)
 	if err != nil {
 		t.Error(err)
@@ -148,7 +152,11 @@ func TestOutputResultsJSON(t *testing.T) {
 func TestOutputResults(t *testing.T) {
 	outcfg := &OutputConfig{}
 	controls := &check.Controls{}
-	summary := check.Summary{}
+	summary := check.Summary{
+		Pass: 10,
+		Fail: 0,
+		Warn: 2,
+	}
 	err := OutputResults(controls, summary, outcfg)
 	if err != nil {
 		t.Error(err)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -18,6 +18,8 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+
+	"github.com/aquasecurity/bench-common/check"
 )
 
 func TestCheckVersion(t *testing.T) {
@@ -127,5 +129,28 @@ func TestMultiWordReplace(t *testing.T) {
 				t.Fatalf("Expected %s got %s", c.output, s)
 			}
 		})
+	}
+}
+
+func TestOutputResultsJSON(t *testing.T) {
+	outcfg := &OutputConfig{
+		OutputFile: "/tmp/bench-common-tst1.jout",
+		JSONFmt:    true,
+	}
+	controls := &check.Controls{}
+	summary := check.Summary{}
+	err := OutputResults(controls, summary, outcfg)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestOutputResults(t *testing.T) {
+	outcfg := &OutputConfig{}
+	controls := &check.Controls{}
+	summary := check.Summary{}
+	err := OutputResults(controls, summary, outcfg)
+	if err != nil {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
Clients can re-use the `util.OutputResults` function.
Here is an example:
 ```console
outcfg := &util.OutputConfig{
   OutputFile:        outputFile,
   NoRemediations:    noRemediations,
   IncludeTestOutput: includeTestOutput,
}
err = util.OutputResults(controls, summary, outcfg)
...
```