### PR TITLE
Change space to /s in regex query

### DIFF
--- a/auditeval/test.go
+++ b/auditeval/test.go
@@ -160,7 +160,7 @@ func getFlagValue(s, flag string) string {
 	pttns := []string{
 		flag + `\s*=\s*"(.*)"`,
 		flag + `\s*=([^ \n]*)`,
-		flag + ` +([^- ]+)`,
+		flag + `\s+([^-\s]+)`,
 		`(?:^| +)` + `(` + flag + `)` + `(?: |$)`,
 	}
 	for _, pttn := range pttns {


### PR DESCRIPTION
The query didn't catch tabs, because there was ' ' and not '/s'