### PR TITLE
Distinguish or and pipe

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -163,7 +163,7 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 		if subCheck == nil {
 			c.Reason = "Failed to find a valid sub check, check your constraints "
 			c.State = WARN
-			glog.V(1).Info("Failed to find a valid sub check, check your constrains")
+			glog.V(1).Info("Failed to find a valid sub check, check your constraints")
 			return
 		}
 	}

--- a/check/check.go
+++ b/check/check.go
@@ -160,7 +160,7 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 		subCheck = getFirstValidSubCheck(c.SubChecks, definedConstraints)
 
 		if subCheck == nil {
-			c.Reason = "Failed to find a valid sub check, check your constrains "
+			c.Reason = "Failed to find a valid sub check, check your constraints "
 			c.State = WARN
 			glog.V(1).Info("Failed to find a valid sub check, check your constrains")
 			return

--- a/check/check.go
+++ b/check/check.go
@@ -160,9 +160,9 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 		subCheck = getFirstValidSubCheck(c.SubChecks, definedConstraints)
 
 		if subCheck == nil {
-			c.Reason = "Failed to find a valid sub check, check "
+			c.Reason = "Failed to find a valid sub check, check your constrains "
 			c.State = WARN
-			glog.V(1).Info("Failed to find a valid sub check, check ", c.ID)
+			glog.V(1).Info("Failed to find a valid sub check, check your constrains")
 			return
 		}
 	}

--- a/check/check.go
+++ b/check/check.go
@@ -17,7 +17,6 @@ package check
 import (
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/aquasecurity/bench-common/auditeval"
@@ -39,25 +38,10 @@ type Audit string
 // Execute method called by the main logic to execute the Audit's Execute type.
 func (audit Audit) Execute(customConfig ...interface{}) (result string, errMessage string, state State) {
 
-	commands := textToCommand(string(audit))
-
-	// Check if command exists or exit with WARN.
-	for _, cmd := range commands {
-		if !isShellCommand(cmd.Path) {
-			glog.V(1).Infof("%s: command not found", cmd.Path)
-			return result, errMessage, WARN
-		}
-	}
-
-	// Run commands.
-	n := len(commands)
-	if n == 0 {
-		// Likely a warning message.
-		return result, errMessage, WARN
-	}
-
-	res, err := exec.Command("sh", "-c", strings.Replace(string(audit), "\\|", "|", -1)).CombinedOutput()
-
+	res, err := exec.Command("sh", "-c", string(audit)).CombinedOutput()
+	// Errors mean the audit command failed, but that might be what we expect
+	// for example, if we grep for something that is not found, there is a non-zero exit code
+	// But it is a problem if we can't find one of the audit commands to execute
 	if err != nil {
 		errMessage = err.Error()
 	}
@@ -120,6 +104,7 @@ type Check struct {
 	IsMultiple     bool   `yaml:"use_multiple_values"`
 	auditer        Auditer
 	customConfigs  []interface{}
+	Reason         string `json:"reason,omitempty"`
 }
 
 // Group is a collection of similar checks.
@@ -138,12 +123,23 @@ type Group struct {
 func (c *Check) Run(definedConstraints map[string][]string) {
 	// If check type is skip, force result to INFO
 	if c.Type == "skip" {
+		c.Reason = "Test marked as skip"
 		c.State = INFO
 		return
 	}
 
 	//If check type is manual or the check is not scored, force result to WARN
-	if c.Type == "manual" || !c.Scored {
+	if c.Type == "manual" {
+		c.Reason = "Test marked as a manual test"
+		c.State = WARN
+		return
+	}
+
+	// Since this is an Scored check
+	// without tests return a 'WARN' to alert
+	// the user that this check needs attention
+	if c.Scored && len(strings.TrimSpace(c.Type)) == 0 && c.Tests == nil {
+		c.Reason = "There are no suitable tests"
 		c.State = WARN
 		return
 	}
@@ -164,6 +160,7 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 		subCheck = getFirstValidSubCheck(c.SubChecks, definedConstraints)
 
 		if subCheck == nil {
+			c.Reason = "Failed to find a valid sub check, check "
 			c.State = WARN
 			glog.V(1).Info("Failed to find a valid sub check, check ", c.ID)
 			return
@@ -176,6 +173,11 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 
 	if errmsgs != "" {
 		glog.V(2).Info(errmsgs)
+		c.Reason = out
+		// Make output more readable
+		if (errmsgs == "exit status 127" || errmsgs == "exit status 1") && strings.HasSuffix(out, "not found\n") {
+			c.Reason = strings.Replace(c.Reason, "sh: 1:", "Command", -1)
+		}
 	}
 
 	if c.State != "" {
@@ -196,86 +198,9 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 	} else {
 		c.State = WARN
 		glog.V(1).Info("Test output contains a nil value")
+		c.Reason = "Test output contains a nil value"
 		return
 	}
-}
-
-// textToCommand transforms an input text representation of commands to be
-// run into a slice of commands.
-// TODO: Make this more robust.
-func textToCommand(s string) (cmds []*exec.Cmd) {
-	if s == "" {
-		return cmds
-	}
-
-	cp := strings.Split(s, "|")
-
-	var newCP []string
-	joinNextPart := false
-
-	// Separate between pipeline and or, differentiate by | and \\|
-	for _, v := range cp {
-		if joinNextPart {
-			newCP[len(newCP)-1] = strings.Join([]string{newCP[len(newCP)-1], strings.TrimSuffix(v, "\\")}, "|")
-			joinNextPart = false
-		} else {
-			newCP = append(newCP, strings.TrimSuffix(v, "\\"))
-		}
-		if strings.HasSuffix(v, "\\") {
-			joinNextPart = true
-		}
-	}
-
-	for _, v := range newCP {
-		v = strings.Trim(v, " ")
-
-		// TODO:
-		// GOAL: To split input text into arguments for exec.Cmd.
-		//
-		// CHALLENGE: The input text may contain quoted strings that
-		// must be passed as a unit to exec.Cmd.
-		// eg. bash -c 'foo bar'
-		// 'foo bar' must be passed as unit to exec.Cmd if not the command
-		// will fail when it is executed.
-		// eg. exec.Cmd("bash", "-c", "foo bar")
-		//
-		// PROBLEM: Current solution assumes the grouped string will always
-		// be at the end of the input text.
-		re := regexp.MustCompile(`^(.*)(['"].*['"])$`)
-		grps := re.FindStringSubmatch(v)
-
-		var cs []string
-		if len(grps) > 0 {
-			s := strings.Trim(grps[1], " ")
-			cs = strings.Split(s, " ")
-
-			s1 := grps[len(grps)-1]
-			s1 = strings.Trim(s1, "'\"")
-
-			cs = append(cs, s1)
-		} else {
-			cs = strings.Split(v, " ")
-		}
-
-		cmd := exec.Command(cs[0], cs[1:]...)
-		cmds = append(cmds, cmd)
-	}
-
-	return cmds
-}
-
-func isShellCommand(s string) bool {
-	cmd := exec.Command("/bin/sh", "-c", "command -v "+s)
-
-	out, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-
-	if strings.Contains(string(out), s) {
-		return true
-	}
-	return false
 }
 
 func runAuditCommands(c BaseCheck) (output, errMessage string, state State) {

--- a/check/check.go
+++ b/check/check.go
@@ -41,7 +41,8 @@ func (audit Audit) Execute(customConfig ...interface{}) (result string, errMessa
 	res, err := exec.Command("sh", "-c", string(audit)).CombinedOutput()
 	// Errors mean the audit command failed, but that might be what we expect
 	// for example, if we grep for something that is not found, there is a non-zero exit code
-	// But it is a problem if we can't find one of the audit commands to execute
+	// It is a problem if we can't find one of the audit commands to execute, but we deal 
+	// with this case in (c *Check) Run() 
 	if err != nil {
 		errMessage = err.Error()
 	}

--- a/check/check.go
+++ b/check/check.go
@@ -139,7 +139,7 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 	// without tests return a 'WARN' to alert
 	// the user that this check needs attention
 	if c.Scored && len(strings.TrimSpace(c.Type)) == 0 && c.Tests == nil {
-		c.Reason = "There are no suitable tests"
+		c.Reason = "There are no test items"
 		c.State = WARN
 		return
 	}

--- a/check/check.go
+++ b/check/check.go
@@ -139,7 +139,7 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 	// Since this is an Scored check
 	// without tests return a 'WARN' to alert
 	// the user that this check needs attention
-	if c.Scored && len(strings.TrimSpace(c.Type)) == 0 && c.Tests == nil {
+	if len(strings.TrimSpace(c.Type)) == 0 && c.Tests == nil {
 		c.Reason = "There are no test items"
 		c.State = WARN
 		return

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -34,13 +34,11 @@ func TestCheck_Run(t *testing.T) {
 
 	checkTypeManual := Check{Type: "manual", Tests: ts, Scored: true, auditer: Audit("ps -ef")}
 	checkTypeSkip := Check{Type: "skip", Tests: ts, Scored: true, auditer: Audit("ps -ef")}
-	checkNotScored := Check{Type: "", Tests: ts, Scored: false, auditer: Audit("ps -ef")}
 	checkNoTests := Check{Type: "", Scored: true, auditer: Audit("")}
 
 	testCases := []TestCase{
 		{check: checkTypeManual, Expected: WARN},
 		{check: checkTypeSkip, Expected: INFO},
-		{check: checkNotScored, Expected: WARN}, // Not scored checks with no type should be marked warn
 		{check: checkNoTests, Expected: WARN},   // If there are no tests in the check, warn
 	}
 

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/aquasecurity/bench-common/auditeval"
@@ -191,4 +192,71 @@ func TestGetFirstValidSubCheck(t *testing.T) {
 			}
 		}
 	}
+}
+func TestTextToCommand(t *testing.T) {
+	type TestCase struct {
+		auditCommand          string
+		expectedSlicedCommand []string
+	}
+
+	// For each test case, we want get the different commands separated by | and exclude the \\|
+	// which stand for the use of | as OR operator and not as a pipe.
+	testCases := []TestCase{
+		{
+			// Test for mixed case of pipeline and or cases
+			auditCommand: "grep -E -i \"(\\\\v\\|\\\\r\\|\\\\m\\|\\\\s)\\|$(grep '^ID=' /etc/os-release | cut -d= -f2 | sed -e 's/\"//g'))\" /etc/motd",
+			expectedSlicedCommand: []string{
+				"grep -E -i \"(\\\\v|\\\\r|\\\\m|\\\\s)|$(grep '^ID=' /etc/os-release",
+				"cut -d= -f2",
+				"sed -e 's/\"//g'))\" /etc/motd"},
+		},
+		{
+			// Test for regular pipe
+			auditCommand: "lsmod | grep cramfs",
+			expectedSlicedCommand: []string{
+				"lsmod",
+				"grep cramfs"},
+		},
+		{
+			// Test for | as Or
+			auditCommand: "grep -E \"^(server\\|pool)\" /etc/ntp.conf",
+			expectedSlicedCommand: []string{
+				"grep -E \"^(server|pool)\" /etc/ntp.conf"},
+		},
+	}
+	for i, testCase := range testCases {
+		commands := textToCommand(testCase.auditCommand)
+		for j, command := range commands {
+			testSlicedCommand := strings.Join(command.Args[:], " ")
+			if testSlicedCommand != testCase.expectedSlicedCommand[j] {
+				t.Errorf("case %d expected:%v, got:%v\n", i, testCase.expectedSlicedCommand[j], testSlicedCommand)
+			}
+		}
+	}
+}
+func TestIsShellCommand(t *testing.T) {
+	type TestCase struct {
+		command  string
+		Expected bool
+	}
+
+	// For each test case, we want to find the first subcheck that matches the constraints in testDefinedConstraints
+	testCases := []TestCase{
+		{
+			// Exist command
+			command:  "/bin/grep",
+			Expected: true,
+		},
+		{
+			// Non exist command
+			command:  "/bin/nonExistCommand",
+			Expected: false,
+		},
+	}
+	for ii, testCase := range testCases {
+		if isShellCommand(testCase.command) != testCase.Expected {
+			t.Errorf("case %d expected for isShellCommand(\"%v\") to return: %v\n", ii, testCase.command, testCase.Expected)
+		}
+	}
+
 }

--- a/util/util.go
+++ b/util/util.go
@@ -106,8 +106,10 @@ func PrettyPrint(r *check.Controls, summary check.Summary, noRemediations, inclu
 		colors[check.WARN].Printf("== Remediations ==\n")
 		for _, g := range r.Groups {
 			for _, c := range g.Checks {
-				if c.State != check.PASS {
+				if (c.State != check.PASS && c.Reason == "") || (c.Type == "manual") {
 					fmt.Printf("%s %s\n", c.ID, c.Remediation)
+				} else if c.State != check.PASS {
+					fmt.Printf("%s %s\n", c.ID, c.Reason)
 				}
 			}
 		}


### PR DESCRIPTION
https://github.com/aquasecurity/linux-bench/issues/49 
The problem in those tests was that the engine didn't separated between the different uses of pipeline, and therefore tried to run non-exist commands.   