### PR TITLE
Add bitmask flag

### DIFF
--- a/auditeval/test.go
+++ b/auditeval/test.go
@@ -302,6 +302,16 @@ func compareOp(tCompareOp string, flagVal string, tCompareValue string) (bool, s
 		s := splitAndRemoveLastSeparator(flagVal, defaultArraySeparator)
 		target := splitAndRemoveLastSeparator(tCompareValue, defaultArraySeparator)
 		testResult = allElementsValid(s, target)
+
+	case "bitmask":
+		expectedResultPattern = "bitmask '%s' AND '%s'"
+		requested, err := strconv.ParseInt(flagVal, 8, 64)
+		max, err := strconv.ParseInt(tCompareValue, 8, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Not numeric value - flag: %q - compareValue: %q %v\n", flagVal, tCompareValue, err)
+			os.Exit(1)
+		}
+		testResult = (max & requested) == requested
 	default:
 		return testResult, expectedResultPattern, nil
 	}

--- a/auditeval/test.go
+++ b/auditeval/test.go
@@ -306,6 +306,10 @@ func compareOp(tCompareOp string, flagVal string, tCompareValue string) (bool, s
 	case "bitmask":
 		expectedResultPattern = "bitmask '%s' AND '%s'"
 		requested, err := strconv.ParseInt(flagVal, 8, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Not numeric value - flag: %q - compareValue: %q %v\n", flagVal, tCompareValue, err)
+			os.Exit(1)
+		}
 		max, err := strconv.ParseInt(tCompareValue, 8, 64)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Not numeric value - flag: %q - compareValue: %q %v\n", flagVal, tCompareValue, err)

--- a/auditeval/test_test.go
+++ b/auditeval/test_test.go
@@ -666,6 +666,20 @@ func TestCompareOp(t *testing.T) {
 		{label: "op=valid_elements, valid_elements expectedResultPattern empty", op: "valid_elements", flagVal: "a,b",
 			compareValue: "", expectedResultPattern: "'a,b' contains valid elements from ''",
 			testResult: false},
+
+		// Test Op "bitmask"
+		{label: "op=bitmask, 644 AND 640", op: "bitmask", flagVal: "640",
+			compareValue: "644", expectedResultPattern: "bitmask '640' AND '644'",
+			testResult: true},
+		{label: "op=bitmask, 644 AND 777", op: "bitmask", flagVal: "777",
+			compareValue: "644", expectedResultPattern: "bitmask '777' AND '644'",
+			testResult: false},
+		{label: "op=bitmask, 644 AND 444", op: "bitmask", flagVal: "444",
+			compareValue: "644", expectedResultPattern: "bitmask '444' AND '644'",
+			testResult: true},
+		{label: "op=bitmask, 644 AND 211", op: "bitmask", flagVal: "211",
+			compareValue: "644", expectedResultPattern: "bitmask '211' AND '644'",
+			testResult: false},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Bitwise AND between two value in order to compare file permissions.
Already been done and tested in kube-bench: https://github.com/aquasecurity/kube-bench/pull/565.
