### PR TITLE
Fix SubChecks from not running

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -139,7 +139,7 @@ func (c *Check) Run(definedConstraints map[string][]string) {
 	// Since this is an Scored check
 	// without tests return a 'WARN' to alert
 	// the user that this check needs attention
-	if len(strings.TrimSpace(c.Type)) == 0 && c.Tests == nil {
+	if len(strings.TrimSpace(c.Type)) == 0 && c.Tests == nil && c.SubChecks == nil{
 		c.Reason = "There are no test items"
 		c.State = WARN
 		return

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -20,6 +20,22 @@ test_items:
 - flag: "root"
   set: true
 `
+const def2 = `---
+id: 1.1
+text: "This is a test test (Scored)"
+sub_checks:
+- check:
+    audit: "anything"
+    tests:
+      test_items:
+      - flag: ""
+        compare:
+          op: eq
+          value: ""
+        set: true			  
+    remediation: "It should pass :) "
+    scored: true
+`
 
 func TestCheck_Run(t *testing.T) {
 	type TestCase struct {
@@ -31,7 +47,12 @@ func TestCheck_Run(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(def1), ts); err != nil {
 		t.Fatalf("error unmarshaling tests yaml %v", err)
 	}
-
+	
+	checkSubChecks := new(Check)
+	if err := yaml.Unmarshal([]byte(def2), checkSubChecks); err != nil {
+		t.Fatalf("error unmarshaling check yaml %v", err)
+	}
+	
 	checkTypeManual := Check{Type: "manual", Tests: ts, Scored: true, auditer: Audit("ps -ef")}
 	checkTypeSkip := Check{Type: "skip", Tests: ts, Scored: true, auditer: Audit("ps -ef")}
 	checkNoTests := Check{Type: "", Scored: true, auditer: Audit("")}
@@ -40,6 +61,7 @@ func TestCheck_Run(t *testing.T) {
 		{check: checkTypeManual, Expected: WARN},
 		{check: checkTypeSkip, Expected: INFO},
 		{check: checkNoTests, Expected: WARN},   // If there are no tests in the check, warn
+		{check: *checkSubChecks, Expected: PASS},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
When a test has a SubCheck, it appears to not have tests (because test items are inside -check)
So when checking if there is no test items, we need to check there are no SubChecks.