### PR TITLE
Changes done to normalize description for control,group & check in case of docker-bench cis and kube-bench cis

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -92,7 +92,8 @@ type SubCheck struct {
 // Check contains information about a recommendation.
 type Check struct {
 	ID             string           `yaml:"id" json:"test_number"`
-	Description    string           `json:"test_desc" yaml:"text"`
+	Description    string           `json:"test_desc"`
+	Text           string           `json:"-"`
 	Set            bool             `json:"-"`
 	SubChecks      []*SubCheck      `yaml:"sub_checks"`
 	AuditType      AuditType        `json:"audit_type"`
@@ -115,7 +116,8 @@ type Check struct {
 // Group is a collection of similar checks.
 type Group struct {
 	ID          string              `yaml:"id" json:"section"`
-	Description string              `json:"desc" yaml:"text"`
+	Description string              `json:"desc"`
+	Text        string              `json:"-"`
 	Constraints map[string][]string `yaml:"constraints"`
 	Type        string              `yaml:"type" json:"type"`
 	Checks      []*Check            `json:"results"`

--- a/check/controls.go
+++ b/check/controls.go
@@ -32,7 +32,8 @@ type Auditer interface {
 // Controls holds all controls to check for master nodes.
 type Controls struct {
 	ID          string   `yaml:"id" json:"id"`
-	Description string   `json:"text" yaml:"text"`
+	Description string   `json:"text"`
+	Text        string   `json:"-"`
 	Groups      []*Group `json:"tests" yaml:"groups"`
 	Summary
 	DefinedConstraints map[string][]string


### PR DESCRIPTION
There are two ways to set the description of a control: via controls.Description or via controls.Text
If controls.Description is empty, then the description is set via control.Text - controls.Description has priority.
Docker-bench CIS (docker-bench) will set controls.Description, and K8s CIS (kube-bench) will set controls.Text. The same applies to groups and checks.

Kube-Bench: https://github.com/aquasecurity/kube-bench/blob/main/cfg/cis-1.20/master.yaml#L5
Docker-Bench: https://github.com/aquasecurity/docker-bench/blob/main/cfg/cis-1.3.1/definitions.yaml#L4
	   
The output struct is normalized such that controls.Description is set in both cases (controls.Description and controls.Text).