### PR TITLE
Fix/regular

### DIFF
--- a/auditeval/test.go
+++ b/auditeval/test.go
@@ -168,7 +168,7 @@ func getFlagValue(s, flag string) string {
 	var flagVal string
 	pttns := []string{
 		`(?:^|[\s]+)"?` + flag + `"?\s*[=:][\r\t\f\v ]*"(.*)"`,
-		`(?:^|[\s]+)"?` + flag + `"?\s*[=:][\r\t\f\v ]*([^\s]*)`,
+		`(?:^|[\s]*)"?` + flag + `"?\s*[=:][\r\t\f\v ]*([^\s]*)`,
 		`(?:^|[\s]+)"?` + flag + `"?\s+([^-\s]+)`,
 		`(?:^|[\s]+)` + `(` + flag + `)` + `(?:[\s]|$)`,
 	}

--- a/auditeval/test.go
+++ b/auditeval/test.go
@@ -168,9 +168,10 @@ func getFlagValue(s, flag string) string {
 	var flagVal string
 	pttns := []string{
 		`(?:^|[\s]+)"?` + flag + `"?\s*[=:][\r\t\f\v ]*"(.*)"`,
-		`(?:^|[\s]*)"?` + flag + `"?\s*[=:][\r\t\f\v ]*([^\s]*)`,
+		`(?:^|[\s]+)"?` + flag + `"?\s*[=:][\r\t\f\v ]*([^\s]*)`,
 		`(?:^|[\s]+)"?` + flag + `"?\s+([^-\s]+)`,
 		`(?:^|[\s]+)` + `(` + flag + `)` + `(?:[\s]|$)`,
+		flag + `[=:]([^\s]*)`,
 	}
 	for _, pttn := range pttns {
 		flagRe := regexp.MustCompile(pttn)

--- a/auditeval/test_test.go
+++ b/auditeval/test_test.go
@@ -131,6 +131,7 @@ func Test_getFlagValue(t *testing.T) {
 		// Check for empty values
 		{Input: "XXX: User=", Flag: "User", Expected: ""},
 		{Input: "XXX: User= ", Flag: "User", Expected: ""},
+		{Input: "XXX:User=", Flag: "User", Expected: ""}, // There is 0 space between Colon and Flag
 		// Check flag as is
 		{Input: "--flag", Flag: "--flag", Expected: "--flag"},
 		{Input: " --flag", Flag: "--flag", Expected: "--flag"},


### PR DESCRIPTION
#  Inability to accurately extract keywords from the audit's output for comparison with flags
## Issue
https://github.com/aquasecurity/docker-bench/issues/108#issue-1846124623
## Step
1. Run the audit to see if there is a container that shares the user namespace.
```bash
$ docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:UsernsMode={{ .HostConfig.UsernsMode }}'
25bb4ff9b617445860b2db256789b6fc6974b563ec3fd162b4b5a2030b2a6dc3:UsernsMode=
c7536667b00fcd4e258ade2e7cea8412e838093b644905b60770e0557e8379a9:UsernsMode=host
```
2. Assign the output to `s` and pass it to the `getFlagValue`
```Bash
func getFlagValue(s, flag string) string {
  if flag == "" {
    return s
  }

  var flagVal string
  pttns := []string{
    `(?:^|[\s]+)"?` + flag + `"?\s*[=:][\r\t\f\v ]*"(.*)"`,
    `(?:^|[\s]+)"?` + flag + `"?\s*[=:][\r\t\f\v ]*([^\s]*)`,
    `(?:^|[\s]+)"?` + flag + `"?\s+([^-\s]+)`,
    `(?:^|[\s]+)` + `(` + flag + `)` + `(?:[\s]|$)`,
  }
  for _, pttn := range pttns {
    flagRe := regexp.MustCompile(pttn)
    vals := flagRe.FindStringSubmatch(s)
    for i, currentValue := range vals {
      if i == 0 {
        continue
      }
      if len(currentValue) > 0 {
        flagVal = currentValue
        return flagVal
      }
    }
  }
  return flagVal
}
```
3.It returned an empty string instead of a `host`.
## Modification
There may be no whitespace  before `flag`.
before
<img width="1068" alt="image" src="https://github.com/aquasecurity/bench-common/assets/44939500/7440dccd-f1d6-4a4e-bfcd-a0c318fe25c9">

after
<img width="1072" alt="image" src="https://github.com/aquasecurity/bench-common/assets/44939500/b95018fe-2440-4411-84c5-1de408c4802b">

